### PR TITLE
Add checks to ensure hmmCopy objects are correct

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@ editor_options:
 * Converted `plotPCA` into a method for the `qsea` defined method.
 * `plotPCA` gains a `verbose` option to turn off most of the messages produced.
 * `getSampleTable` is now defined for PCA/UMAP objects.
+* Prevent exponentially increasing numbers of rows in CNV object when incorrect hmmCopy objects are provided, [fixes issue #26](https://github.com/cruk-mi/mesa/issues/26) reported by @lbeltrame.
 
 # mesa 0.5.1
 

--- a/R/makeQset.R
+++ b/R/makeQset.R
@@ -222,12 +222,38 @@ makeQset <- function(sampleTable,
 
     }
 
-      if (is.null(hmmCopyGC)) {
+    if (is.null(hmmCopyGC)) {
       stop("No hmmCopy GC content object provided!")
+      } else {
+        requiredColumns <- c("chr","start","end","gc")
+        columnDiff <- setdiff(colnames(hmmCopyGC), requiredColumns)
+      if(length(columnDiff) > 0) {
+        stop(glue::glue("hmmCopyGC object missing required columns: {paste(columnDiff, collapse = ' ')}"))
+      } 
+      objectWindowSize <- hmmCopyGC %>% mutate(size = end - start + 1) %>% pull(size) %>% unique()
+      
+      if(length(objectWindowSize) != 1) {
+        stop(glue::glue("hmmCopyGC object should have constant window size for all windows."))
+      } else if (objectWindowSize != CNVwindowSize) {
+        stop(glue::glue("hmmCopyGC object window size should be the same as the CNVwindowSize."))
+      }
     }
 
     if (is.null(hmmCopyMap)) {
       stop("No hmmCopy Mapability file provided!")
+    } else {
+      requiredColumns <- c("chr","start","end","map")
+      columnDiff <- setdiff(colnames(hmmCopyMap), requiredColumns)
+      if(length(columnDiff) > 0) {
+        stop(glue::glue("hmmCopyMap object missing required columns: {paste(columnDiff, collapse = ' ')}"))
+      } 
+      objectWindowSize <- hmmCopyMap %>% mutate(size = end - start + 1) %>% pull(size) %>% unique()
+      
+      if(length(objectWindowSize) != 1) {
+        stop(glue::glue("hmmCopyMap object should have constant window size for all windows."))
+      } else if (objectWindowSize != CNVwindowSize) {
+        stop(glue::glue("hmmCopyMap object window size should be the same as the CNVwindowSize."))
+      }
     }
 
     # use HMMCopy directly, with default settings

--- a/R/utils.R
+++ b/R/utils.R
@@ -134,3 +134,8 @@ asValidGranges <- function(object){
   stop("Object can not be coerced to a GRanges object")
 
 }
+
+#' This function captures a printed form of the object x, for use in error messages
+#' Taken from https://stackoverflow.com/a/26083626 by Richie Cotton
+#' @param x An object to capture
+print_and_capture <- function(x) {paste(capture.output(print(x)), collapse = "\n") }


### PR DESCRIPTION
Fixes #26 by adding checks to ensure that exponential increases of the size of the data frame don't happen with the `join_overlap_left` commands.