### PR TITLE
Add reproducible R dev environment in code spaces with .devcontainer setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,22 @@
+# Start from official Rocker R image
+FROM rocker/r-ver:4.3.3
+
+# Install system dependencies for R packages and Git
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    curl \
+    ca-certificates \
+    sudo \
+    libcurl4-openssl-dev \
+    libssl-dev \
+    libxml2-dev \
+    libpng-dev \
+    libfreetype6-dev \
+    libharfbuzz-dev \
+    libfribidi-dev \
+    libfontconfig1-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Preinstall bootstrap R packages (for smoother Codespace startup)
+RUN R -e "install.packages(c('jsonlite','BiocManager'), repos='https://cloud.r-project.org')"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -20,11 +20,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libpng-dev \
     libssl-dev \
     libtiff-dev \
+    libtiff5-dev \
     libwebp-dev \
     libxml2-dev \
+    libcurl4-openssl-dev \
     sudo \
     zlib1g-dev \
-    libcurl4-openssl-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     ca-certificates \
     sudo \
+    build-essential \
     libcurl4-openssl-dev \
     libssl-dev \
     libxml2-dev \
@@ -18,5 +19,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Preinstall bootstrap R packages (for smoother Codespace startup)
-RUN R -e "install.packages(c('jsonlite','BiocManager'), repos='https://cloud.r-project.org')"
+# Create vscode user (UID 1000) with sudo privileges
+RUN useradd -ms /bin/bash vscode \
+    && echo "vscode ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/90-vscode
+
+# Preinstall bootstrap packages globally (needed before user lib init)
+RUN R -e "install.packages(c('jsonlite','BiocManager','languageserver'), repos='https://cloud.r-project.org')"
+
+# Switch to vscode user
+USER vscode
+WORKDIR /workspaces/mesa

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,24 +3,31 @@ FROM rocker/r-ver:4.3.3
 
 # Install system dependencies for R packages and Git
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    git \
-    curl \
-    ca-certificates \
-    sudo \
     build-essential \
-    libcurl4-openssl-dev \
-    libssl-dev \
-    libxml2-dev \
-    libpng-dev \
-    libjpeg-dev \
-    libtiff-dev \
-    libicu-dev \
-    libfreetype6-dev \
-    libharfbuzz-dev \
-    libfribidi-dev \
+    ca-certificates \
+    curl \
+    git \
+    libbz2-dev \
     libfontconfig1-dev \
+    libfreetype6-dev \
+    libfribidi-dev \
+    libharfbuzz-dev \
+    libicu-dev \
+    libjpeg-dev \
+    liblzma-dev \
+    libncurses5-dev \
+    libncursesw5-dev \
+    libpng-dev \
+    libssl-dev \
+    libtiff-dev \
+    libwebp-dev \
+    libxml2-dev \
+    sudo \
+    zlib1g-dev \
+    libcurl4-openssl-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
 
 # Create vscode user (UID 1000) with sudo privileges
 RUN useradd -ms /bin/bash vscode \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,6 +12,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libssl-dev \
     libxml2-dev \
     libpng-dev \
+    libjpeg-dev \
+    libtiff-dev \
+    libicu-dev \
     libfreetype6-dev \
     libharfbuzz-dev \
     libfribidi-dev \
@@ -24,7 +27,7 @@ RUN useradd -ms /bin/bash vscode \
     && echo "vscode ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/90-vscode
 
 # Preinstall bootstrap packages globally (needed before user lib init)
-RUN R -e "install.packages(c('jsonlite','BiocManager','languageserver'), repos='https://cloud.r-project.org')"
+RUN R -e "install.packages(c('jsonlite','BiocManager','languageserver','remotes'), repos='https://cloud.r-project.org')"
 
 # Switch to vscode user
 USER vscode

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,6 +26,5 @@
   "remoteUser": "vscode",
 
   "postCreateCommand": "Rscript .devcontainer/install.R || true",
-  "postStartCommand": "Rscript -e 'if (!requireNamespace(\"devtools\", quietly=TRUE)) source(\".devcontainer/install.R\")'"
-
+  "postStartCommand": "Rscript -e 'if (!requireNamespace(\"ggtree\", quietly=TRUE) || !requireNamespace(\"devtools\", quietly=TRUE)) source(\".devcontainer/install.R\")'"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,5 +25,7 @@
 
   "remoteUser": "vscode",
 
-  "postCreateCommand": "Rscript .devcontainer/install.R"
+  "postCreateCommand": "Rscript .devcontainer/install.R || true",
+  "postStartCommand": "Rscript -e 'if (!requireNamespace(\"devtools\", quietly=TRUE)) source(\".devcontainer/install.R\")'"
+
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+{
+  "name": "mesa-dev",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "REditorSupport.r",
+        "ikuyadeu.r",
+        "ms-python.python"
+      ]
+    }
+  },
+
+  "remoteEnv": {
+    "R_LIBS_USER": "/home/vscode/R/x86_64-pc-linux-gnu-library/4.3"
+  },
+
+  "postCreateCommand": "Rscript .devcontainer/install.R"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,13 +10,20 @@
         "REditorSupport.r",
         "ikuyadeu.r",
         "ms-python.python"
-      ]
+      ],
+      "settings": {
+        "r.lsp.path": "R",
+        "r.rterm.option": ["--no-save", "--no-restore", "--quiet"],
+        "r.libPaths": ["/home/vscode/R/x86_64-pc-linux-gnu-library/4.3"]
+      }
     }
   },
 
   "remoteEnv": {
     "R_LIBS_USER": "/home/vscode/R/x86_64-pc-linux-gnu-library/4.3"
   },
+
+  "remoteUser": "vscode",
 
   "postCreateCommand": "Rscript .devcontainer/install.R"
 }

--- a/.devcontainer/install.R
+++ b/.devcontainer/install.R
@@ -12,7 +12,7 @@ if (!requireNamespace("remotes", quietly = TRUE)) {
   install.packages("remotes", lib = user_lib, repos = "https://cloud.r-project.org")
 }
 
-# --- Pin exact versions to avoid fgsea/ggtree issues ---
+# --- Pin critical versions ---
 remotes::install_version(
   "BH",
   version = "1.81.0-1",
@@ -21,88 +21,66 @@ remotes::install_version(
   type = "source"
 )
 
+# ggplot2 4.0.0 required by ggtree >= 3.99.0
 remotes::install_version(
   "ggplot2",
-  version = "3.4.4",
+  version = "4.0.0",
   lib = user_lib,
   repos = "https://cloud.r-project.org",
   type = "source"
 )
 
-# --- Install BiocManager if missing ---
+# --- BiocManager for Bioconductor installs ---
 if (!requireNamespace("BiocManager", quietly = TRUE)) {
   install.packages("BiocManager", lib = user_lib, repos = "https://cloud.r-project.org")
 }
 
-# --- Install ggtree from Bioconductor 3.18, don't upgrade pinned packages ---
-BiocManager::install(
-  "ggtree",
-  version = "3.18",
-  ask = FALSE,
-  update = FALSE,   # 👈 prevents BH/ggplot2 from being overwritten
-  lib = user_lib
-)
+# --- Upgrade ggiraph (>=0.9.1 required for ggtree dev) ---
+remotes::install_version("ggiraph", version = "0.9.1", lib = user_lib, repos = "https://cloud.r-project.org")
 
-# --- Commented for now (extend later when stable) ---
-# install.packages("devtools", lib = user_lib, repos = "https://cloud.r-project.org")
-# BiocManager::install(c("qsea", "MEDIPS", "clusterProfiler"), lib = user_lib, ask = FALSE)
+# --- Install ggtree from GitHub (latest dev release) ---
+remotes::install_github("YuLab-SMU/ggtree", lib = user_lib, upgrade = "never")
 
-message("✅ Test environment ready with pinned BH 1.81.0-1 + ggplot2 3.4.4 + ggtree 3.10.1")
+message("✅ Test environment ready with BH 1.81.0-1, ggplot2 4.0.0, and ggtree 3.99.0")
 
-# # Ensure user library path exists
-# user_lib <- Sys.getenv("R_LIBS_USER")
-# if (!dir.exists(user_lib)) {
-#   dir.create(user_lib, recursive = TRUE, showWarnings = FALSE)
-# }
-# .libPaths(c(user_lib, .libPaths()))
-# 
-# options(repos = c(CRAN = "https://cloud.r-project.org"))
-# 
-# # Bootstrap remotes
-# if (!requireNamespace("remotes", quietly = TRUE)) {
-#   install.packages("remotes", lib = user_lib, repos = "https://cloud.r-project.org")
-# }
-# 
-# # --- Pin critical versions to avoid build failures ---
-# remotes::install_version("BH", version = "1.81.0-1", lib = user_lib, repos = "https://cloud.r-project.org")
-# remotes::install_version("ggplot2", version = "3.4.4", lib = user_lib, repos = "https://cloud.r-project.org")
-# 
-# 
-# # Install devtools (needed for devtools::test)
-# install.packages("devtools", lib = user_lib, repos = "https://cloud.r-project.org")
-# 
-# # Core CRAN dependencies (avoid full tidyverse to skip Google API deps)
-# install.packages(c(
-#   "httr", "png", "RCurl", "igraph", "ggraph",
-#   "rlang", "dplyr", "tibble", "tidyr", "readr",
-#   "purrr", "stringr", "forcats",
-#   "Rcpp", "RcppAnnoy", "RcppProgress",
-#   "uwot"
-# ), lib = user_lib)
-# 
-# # Bioconductor version 3.18
-# BiocManager::install(version = "3.18", ask = FALSE)
-# 
-# # Core Bioconductor packages
-# BiocManager::install(c(
-#   "BiocGenerics", "GenomeInfoDb", "IRanges", "S4Vectors",
-#   "Biostrings", "GenomicRanges", "Rhtslib", "Rsamtools",
-#   "SummarizedExperiment"
-# ), lib = user_lib, ask = FALSE, update = TRUE)
-# 
-# # Annotation + genomics
-# BiocManager::install(c(
-#   "AnnotationDbi", "GenomicFeatures", "GenomicAlignments", "BSgenome",
-#   "TxDb.Hsapiens.UCSC.hg38.knownGene",
-#   "TxDb.Mmusculus.UCSC.mm10.knownGene",
-#   "org.Mm.eg.db"
-# ), lib = user_lib, ask = FALSE, update = TRUE)
-# 
-# # High-level analysis packages
-# BiocManager::install(c(
-#   "qsea", "MEDIPS", "ChIPseeker", "clusterProfiler",
-#   "DOSE", "GOSemSim", "enrichplot", "ReactomePA",
-#   "ggtree", "treeio", "tidytree"
-# ), lib = user_lib, ask = FALSE, update = TRUE)
-# 
-# message("✅ R dev environment ready with user library at: ", user_lib)
+
+
+# Install devtools (needed for devtools::test)
+install.packages("devtools", lib = user_lib, repos = "https://cloud.r-project.org")
+
+message("✅ Core graphics stack ready: BH 1.81.0-1, ggplot2 4.0.0, ggiraph 0.9.1 ggtree 3.99.0")
+
+# --- CRAN core deps (without full tidyverse) ---
+install.packages(c(
+  "httr", "png", "RCurl", "igraph", "ggraph",
+  "rlang", "dplyr", "tibble", "tidyr", "readr",
+  "purrr", "stringr", "forcats",
+  "Rcpp", "RcppAnnoy", "RcppProgress", "uwot"
+), lib = user_lib)
+
+# --- Bioconductor 3.18 ---
+BiocManager::install(version = "3.18", ask = FALSE)
+
+# Core Bioconductor packages
+BiocManager::install(c(
+  "BiocGenerics", "GenomeInfoDb", "IRanges", "S4Vectors",
+  "Biostrings", "GenomicRanges", "Rhtslib", "Rsamtools",
+  "SummarizedExperiment"
+), lib = user_lib, ask = FALSE, update = FALSE)
+
+# Annotation + genomics
+BiocManager::install(c(
+  "AnnotationDbi", "GenomicFeatures", "GenomicAlignments", "BSgenome",
+  "TxDb.Hsapiens.UCSC.hg38.knownGene",
+  "TxDb.Mmusculus.UCSC.mm10.knownGene",
+  "org.Mm.eg.db"
+), lib = user_lib, ask = FALSE, update = FALSE)
+
+# High-level analysis packages
+BiocManager::install(c(
+  "qsea", "MEDIPS", "ChIPseeker", "clusterProfiler",
+  "DOSE", "GOSemSim", "enrichplot", "ReactomePA",
+  "treeio", "tidytree"
+), lib = user_lib, ask = FALSE, update = FALSE)
+
+message("✅ Full R dev environment ready in: ", user_lib)

--- a/.devcontainer/install.R
+++ b/.devcontainer/install.R
@@ -7,7 +7,7 @@ if (!dir.exists(user_lib)) {
 
 options(
   repos = c(CRAN = "https://cloud.r-project.org"),
-  install.packages.check.source = "no"  # don’t “update” to source if binary differs
+  install.packages.check.source = "no" # don’t “update” to source if binary differs
 )
 Sys.setenv(R_REMOTES_NO_ERRORS_FROM_WARNINGS = "true")
 
@@ -19,39 +19,22 @@ if (!requireNamespace("BiocManager", quietly = TRUE)) {
   install.packages("BiocManager", lib = user_lib, repos = "https://cloud.r-project.org")
 }
 
-# --- Pin critical versions ---
-remotes::install_version(
-  "BH",
-  version = "1.81.0-1",
-  lib = user_lib,
-  repos = "https://cloud.r-project.org",
-  type = "source"
-)
-
-# ggplot2 4.0.0 required by ggtree >= 3.99.0
-remotes::install_version(
-  "ggplot2",
-  version = "4.0.0",
-  lib = user_lib,
-  repos = "https://cloud.r-project.org",
-  type = "source"
-)
-
 # --- Pin CRAN critical versions ---
-remotes::install_version("BH", version = "1.81.0-1", lib = user_lib, repos = "https://cloud.r-project.org", type = "source")
-remotes::install_version("ggplot2", version = "4.0.0", lib = user_lib, repos = "https://cloud.r-project.org", type = "source")
-remotes::install_version("ggiraph", version = "0.9.1", lib = user_lib, repos = "https://cloud.r-project.org")
+remotes::install_version("BH", version = "1.81.0-1", lib = user_lib,
+                         repos = "https://cloud.r-project.org", type = "source", upgrade = "never")
+remotes::install_version("ggplot2", version = "4.0.0", lib = user_lib,
+                         repos = "https://cloud.r-project.org", type = "source", upgrade = "never")
+remotes::install_version("ggiraph", version = "0.9.1", lib = user_lib,
+                         repos = "https://cloud.r-project.org", upgrade = "never")
 
 # --- Install ggtree (dev version, requires pinned deps) ---
 remotes::install_github("YuLab-SMU/ggtree", lib = user_lib, upgrade = "never")
 
-# --- Install devtools ---
-install.packages("devtools", lib = user_lib, repos = "https://cloud.r-project.org")
+# --- Install devtools (needed for devtools::test) ---
+install.packages("devtools", lib = user_lib, repos = "https://cloud.r-project.org",
+                 dependencies = TRUE, INSTALL_opts = "--no-multiarch")
 
-
-message("✅ Core graphics stack ready: BH 1.81.0-1, ggplot2 4.0.0, ggiraph 0.9.1 ggtree 3.99.0")
-
-
+message("✅ Core graphics stack ready: BH 1.81.0-1, ggplot2 4.0.0, ggiraph 0.9.1, ggtree dev")
 
 # --- CRAN core deps (without full tidyverse) ---
 install.packages(c(
@@ -59,41 +42,52 @@ install.packages(c(
   "rlang", "dplyr", "tibble", "tidyr", "readr",
   "purrr", "stringr", "forcats",
   "Rcpp", "RcppAnnoy", "RcppProgress", "uwot"
-), lib = user_lib)
+), lib = user_lib, update = FALSE)
+
+# --- Sanity check before Bioconductor installs ---
+ip <- installed.packages(lib.loc = user_lib)
+
+required <- list(
+  BH       = "1.81.0-1", # pinned for fgsea
+  ggplot2  = "4.0.0",    # required for ggtree >= 3.99.0
+  ggiraph  = "0.9.1",    # required for ggtree dev
+  ggtree   = NA,         # dev version, skip version check
+  devtools = NA          # latest ok
+)
+
+for (pkg in names(required)) {
+  if (!pkg %in% rownames(ip)) {
+    stop("❌ Package ", pkg, " is not installed in ", user_lib)
+  }
+  target_ver <- required[[pkg]]
+  if (!is.na(target_ver)) {
+    inst_ver <- ip[pkg, "Version"]
+    if (inst_ver != target_ver) {
+      stop("❌ Package ", pkg, " version mismatch: installed ", inst_ver,
+           " but expected ", target_ver)
+    }
+  }
+}
 
 
-# # --- Sanity check core graphics stack before Bioconductor ---
-# ip <- installed.packages(lib.loc = user_lib)
-# 
-# required <- list(
-#   BH       = "1.81.0-1",  # pinned because fgsea needs <=1.81
-#   ggplot2  = "4.0.0",     # required for ggtree >= 3.99.0
-#   ggiraph  = "0.9.1",     # required for ggtree dev
-#   fgsea    = NA,          # Bioc package, any version is ok
-#   ggtree   = NA           # dev version, skip version check
-# )
-# 
-# for (pkg in names(required)) {
-#   if (!pkg %in% rownames(ip)) {
-#     stop("❌ Package ", pkg, " is not installed in ", user_lib,
-#          ". Please re-run install.R earlier steps.")
-#   }
-#   target_ver <- required[[pkg]]
-#   if (!is.na(target_ver)) {
-#     inst_ver <- ip[pkg, "Version"]
-#     if (inst_ver != target_ver) {
-#       stop("❌ Package ", pkg, " version mismatch: installed ", inst_ver,
-#            " but expected ", target_ver)
-#     }
-#   }
-# }
-# 
-# message("✅ Core graphics stack verified. Proceeding with Bioconductor install…")
-
-# --- Bioconductor 3.18 ---
+# --- Bioconductor 3.18 (set version only) ---
 BiocManager::install(version = "3.18", ask = FALSE)
 
-# Explicitly install fgsea first (critical dep)
+# --- Enforce BH before fgsea ---
+ip <- installed.packages(lib.loc = user_lib)
+if (!"BH" %in% rownames(ip) || ip["BH", "Version"] != "1.81.0-1") {
+  message("⚠️ Reinstalling BH 1.81.0-1 to satisfy fgsea build...")
+  remove.packages("BH", lib = user_lib)  # clean out any wrong version
+  remotes::install_version("BH",
+                           version = "1.81.0-1",
+                           lib = user_lib,
+                           repos = "https://cloud.r-project.org",
+                           type = "source",
+                           upgrade = "never"
+  )
+}
+
+# --- Critical Bioc package: fgsea ---
 BiocManager::install("fgsea", lib = user_lib, ask = FALSE, update = FALSE)
 
 # Core Bioconductor packages

--- a/.devcontainer/install.R
+++ b/.devcontainer/install.R
@@ -7,51 +7,102 @@ if (!dir.exists(user_lib)) {
 
 options(repos = c(CRAN = "https://cloud.r-project.org"))
 
-# Bootstrap remotes
+# --- Bootstrap remotes ---
 if (!requireNamespace("remotes", quietly = TRUE)) {
   install.packages("remotes", lib = user_lib, repos = "https://cloud.r-project.org")
 }
 
-# --- Pin critical versions to avoid build failures ---
-remotes::install_version("BH", version = "1.81.0-1", lib = user_lib, repos = "https://cloud.r-project.org")
-remotes::install_version("ggplot2", version = "3.4.4", lib = user_lib, repos = "https://cloud.r-project.org")
+# --- Pin exact versions to avoid fgsea/ggtree issues ---
+remotes::install_version(
+  "BH",
+  version = "1.81.0-1",
+  lib = user_lib,
+  repos = "https://cloud.r-project.org",
+  type = "source"
+)
 
+remotes::install_version(
+  "ggplot2",
+  version = "3.4.4",
+  lib = user_lib,
+  repos = "https://cloud.r-project.org",
+  type = "source"
+)
 
-# Install devtools (needed for devtools::test)
-install.packages("devtools", lib = user_lib, repos = "https://cloud.r-project.org")
+# --- Install BiocManager if missing ---
+if (!requireNamespace("BiocManager", quietly = TRUE)) {
+  install.packages("BiocManager", lib = user_lib, repos = "https://cloud.r-project.org")
+}
 
-# Core CRAN dependencies (avoid full tidyverse to skip Google API deps)
-install.packages(c(
-  "httr", "png", "RCurl", "igraph", "ggraph",
-  "rlang", "dplyr", "tibble", "tidyr", "readr",
-  "purrr", "stringr", "forcats",
-  "Rcpp", "RcppAnnoy", "RcppProgress",
-  "uwot"
-), lib = user_lib)
+# --- Install ggtree from Bioconductor 3.18, don't upgrade pinned packages ---
+BiocManager::install(
+  "ggtree",
+  version = "3.18",
+  ask = FALSE,
+  update = FALSE,   # 👈 prevents BH/ggplot2 from being overwritten
+  lib = user_lib
+)
 
-# Bioconductor version 3.18
-BiocManager::install(version = "3.18", ask = FALSE)
+# --- Commented for now (extend later when stable) ---
+# install.packages("devtools", lib = user_lib, repos = "https://cloud.r-project.org")
+# BiocManager::install(c("qsea", "MEDIPS", "clusterProfiler"), lib = user_lib, ask = FALSE)
 
-# Core Bioconductor packages
-BiocManager::install(c(
-  "BiocGenerics", "GenomeInfoDb", "IRanges", "S4Vectors",
-  "Biostrings", "GenomicRanges", "Rhtslib", "Rsamtools",
-  "SummarizedExperiment"
-), lib = user_lib, ask = FALSE, update = TRUE)
+message("✅ Test environment ready with pinned BH 1.81.0-1 + ggplot2 3.4.4 + ggtree 3.10.1")
 
-# Annotation + genomics
-BiocManager::install(c(
-  "AnnotationDbi", "GenomicFeatures", "GenomicAlignments", "BSgenome",
-  "TxDb.Hsapiens.UCSC.hg38.knownGene",
-  "TxDb.Mmusculus.UCSC.mm10.knownGene",
-  "org.Mm.eg.db"
-), lib = user_lib, ask = FALSE, update = TRUE)
-
-# High-level analysis packages
-BiocManager::install(c(
-  "qsea", "MEDIPS", "ChIPseeker", "clusterProfiler",
-  "DOSE", "GOSemSim", "enrichplot", "ReactomePA",
-  "ggtree", "treeio", "tidytree"
-), lib = user_lib, ask = FALSE, update = TRUE)
-
-message("✅ R dev environment ready with user library at: ", user_lib)
+# # Ensure user library path exists
+# user_lib <- Sys.getenv("R_LIBS_USER")
+# if (!dir.exists(user_lib)) {
+#   dir.create(user_lib, recursive = TRUE, showWarnings = FALSE)
+# }
+# .libPaths(c(user_lib, .libPaths()))
+# 
+# options(repos = c(CRAN = "https://cloud.r-project.org"))
+# 
+# # Bootstrap remotes
+# if (!requireNamespace("remotes", quietly = TRUE)) {
+#   install.packages("remotes", lib = user_lib, repos = "https://cloud.r-project.org")
+# }
+# 
+# # --- Pin critical versions to avoid build failures ---
+# remotes::install_version("BH", version = "1.81.0-1", lib = user_lib, repos = "https://cloud.r-project.org")
+# remotes::install_version("ggplot2", version = "3.4.4", lib = user_lib, repos = "https://cloud.r-project.org")
+# 
+# 
+# # Install devtools (needed for devtools::test)
+# install.packages("devtools", lib = user_lib, repos = "https://cloud.r-project.org")
+# 
+# # Core CRAN dependencies (avoid full tidyverse to skip Google API deps)
+# install.packages(c(
+#   "httr", "png", "RCurl", "igraph", "ggraph",
+#   "rlang", "dplyr", "tibble", "tidyr", "readr",
+#   "purrr", "stringr", "forcats",
+#   "Rcpp", "RcppAnnoy", "RcppProgress",
+#   "uwot"
+# ), lib = user_lib)
+# 
+# # Bioconductor version 3.18
+# BiocManager::install(version = "3.18", ask = FALSE)
+# 
+# # Core Bioconductor packages
+# BiocManager::install(c(
+#   "BiocGenerics", "GenomeInfoDb", "IRanges", "S4Vectors",
+#   "Biostrings", "GenomicRanges", "Rhtslib", "Rsamtools",
+#   "SummarizedExperiment"
+# ), lib = user_lib, ask = FALSE, update = TRUE)
+# 
+# # Annotation + genomics
+# BiocManager::install(c(
+#   "AnnotationDbi", "GenomicFeatures", "GenomicAlignments", "BSgenome",
+#   "TxDb.Hsapiens.UCSC.hg38.knownGene",
+#   "TxDb.Mmusculus.UCSC.mm10.knownGene",
+#   "org.Mm.eg.db"
+# ), lib = user_lib, ask = FALSE, update = TRUE)
+# 
+# # High-level analysis packages
+# BiocManager::install(c(
+#   "qsea", "MEDIPS", "ChIPseeker", "clusterProfiler",
+#   "DOSE", "GOSemSim", "enrichplot", "ReactomePA",
+#   "ggtree", "treeio", "tidytree"
+# ), lib = user_lib, ask = FALSE, update = TRUE)
+# 
+# message("✅ R dev environment ready with user library at: ", user_lib)

--- a/.devcontainer/install.R
+++ b/.devcontainer/install.R
@@ -87,8 +87,9 @@ if (!"BH" %in% rownames(ip) || ip["BH", "Version"] != "1.81.0-1") {
   )
 }
 
-# --- Critical Bioc package: fgsea ---
+# --- Critical Bioc packages ---
 BiocManager::install("fgsea", lib = user_lib, ask = FALSE, update = FALSE)
+BiocManager::install("qsea",  lib = user_lib, ask = FALSE, update = FALSE)
 
 # Core Bioconductor packages
 BiocManager::install(c(
@@ -111,5 +112,15 @@ BiocManager::install(c(
   "DOSE", "GOSemSim", "enrichplot", "ReactomePA",
   "treeio", "tidytree"
 ), lib = user_lib, ask = FALSE, update = FALSE)
+
+# --- Additional test/runtime dependencies ---
+install.packages(c(
+  "pheatmap", "janitor", "hues"
+), lib = user_lib, repos = "https://cloud.r-project.org")
+
+BiocManager::install(c(
+  "plyranges", "ComplexHeatmap", "biomaRt", "circlize"
+), lib = user_lib, ask = FALSE, update = FALSE)
+
 
 message("✅ Full R dev environment ready in: ", user_lib)

--- a/.devcontainer/install.R
+++ b/.devcontainer/install.R
@@ -1,0 +1,58 @@
+# Ensure user library path exists
+user_lib <- Sys.getenv("R_LIBS_USER")
+if (!dir.exists(user_lib)) {
+  dir.create(user_lib, recursive = TRUE, showWarnings = FALSE)
+}
+.libPaths(c(user_lib, .libPaths()))
+
+options(repos = c(CRAN = "https://cloud.r-project.org"))
+
+# --- Bootstrap essentials (needed by devcontainer + Bioconductor) ---
+for (pkg in c("jsonlite", "BiocManager")) {
+  if (!requireNamespace(pkg, quietly = TRUE)) {
+    install.packages(pkg, lib = user_lib, repos = "https://cloud.r-project.org")
+  }
+}
+
+# --- Pin critical versions to avoid build failures ---
+install.packages("BH", version = "1.81.0-1", lib = user_lib, repos = "https://cloud.r-project.org")
+install.packages("ggplot2", version = "3.4.4", lib = user_lib, repos = "https://cloud.r-project.org")
+
+# Install devtools (needed for devtools::test)
+install.packages("devtools", lib = user_lib, repos = "https://cloud.r-project.org")
+
+# Core CRAN dependencies (avoid full tidyverse to skip Google API deps)
+install.packages(c(
+  "httr", "png", "RCurl", "igraph", "ggraph",
+  "rlang", "dplyr", "tibble", "tidyr", "readr",
+  "purrr", "stringr", "forcats",  # tidyverse core
+  "Rcpp", "RcppAnnoy", "RcppProgress",
+  "uwot"
+), lib = user_lib)
+
+# Bioconductor version 3.18
+BiocManager::install(version = "3.18", ask = FALSE)
+
+# Core Bioconductor packages
+BiocManager::install(c(
+  "BiocGenerics", "GenomeInfoDb", "IRanges", "S4Vectors",
+  "Biostrings", "GenomicRanges", "Rhtslib", "Rsamtools",
+  "SummarizedExperiment"
+), lib = user_lib, ask = FALSE, update = TRUE)
+
+# Annotation + genomics
+BiocManager::install(c(
+  "AnnotationDbi", "GenomicFeatures", "GenomicAlignments", "BSgenome",
+  "TxDb.Hsapiens.UCSC.hg38.knownGene",
+  "TxDb.Mmusculus.UCSC.mm10.knownGene",
+  "org.Mm.eg.db"
+), lib = user_lib, ask = FALSE, update = TRUE)
+
+# High-level analysis packages
+BiocManager::install(c(
+  "qsea", "MEDIPS", "ChIPseeker", "clusterProfiler",
+  "DOSE", "GOSemSim", "enrichplot", "ReactomePA",
+  "ggtree", "treeio", "tidytree"
+), lib = user_lib, ask = FALSE, update = TRUE)
+
+message("✅ R dev environment ready with user library at: ", user_lib)

--- a/.devcontainer/install.R
+++ b/.devcontainer/install.R
@@ -7,9 +7,15 @@ if (!dir.exists(user_lib)) {
 
 options(repos = c(CRAN = "https://cloud.r-project.org"))
 
+# Bootstrap remotes
+if (!requireNamespace("remotes", quietly = TRUE)) {
+  install.packages("remotes", lib = user_lib, repos = "https://cloud.r-project.org")
+}
+
 # --- Pin critical versions to avoid build failures ---
-install.packages("BH", version = "1.81.0-1", lib = user_lib, repos = "https://cloud.r-project.org")
-install.packages("ggplot2", version = "3.4.4", lib = user_lib, repos = "https://cloud.r-project.org")
+remotes::install_version("BH", version = "1.81.0-1", lib = user_lib, repos = "https://cloud.r-project.org")
+remotes::install_version("ggplot2", version = "3.4.4", lib = user_lib, repos = "https://cloud.r-project.org")
+
 
 # Install devtools (needed for devtools::test)
 install.packages("devtools", lib = user_lib, repos = "https://cloud.r-project.org")

--- a/.devcontainer/install.R
+++ b/.devcontainer/install.R
@@ -7,13 +7,6 @@ if (!dir.exists(user_lib)) {
 
 options(repos = c(CRAN = "https://cloud.r-project.org"))
 
-# --- Bootstrap essentials (needed by devcontainer + Bioconductor) ---
-for (pkg in c("jsonlite", "BiocManager")) {
-  if (!requireNamespace(pkg, quietly = TRUE)) {
-    install.packages(pkg, lib = user_lib, repos = "https://cloud.r-project.org")
-  }
-}
-
 # --- Pin critical versions to avoid build failures ---
 install.packages("BH", version = "1.81.0-1", lib = user_lib, repos = "https://cloud.r-project.org")
 install.packages("ggplot2", version = "3.4.4", lib = user_lib, repos = "https://cloud.r-project.org")
@@ -25,7 +18,7 @@ install.packages("devtools", lib = user_lib, repos = "https://cloud.r-project.or
 install.packages(c(
   "httr", "png", "RCurl", "igraph", "ggraph",
   "rlang", "dplyr", "tibble", "tidyr", "readr",
-  "purrr", "stringr", "forcats",  # tidyverse core
+  "purrr", "stringr", "forcats",
   "Rcpp", "RcppAnnoy", "RcppProgress",
   "uwot"
 ), lib = user_lib)

--- a/.devcontainer/install.R
+++ b/.devcontainer/install.R
@@ -62,37 +62,39 @@ install.packages(c(
 ), lib = user_lib)
 
 
-# --- Sanity check core graphics stack before Bioconductor ---
-ip <- installed.packages(lib.loc = user_lib)
-
-required <- list(
-  BH       = "1.81.0-1",  # pinned because fgsea needs <=1.81
-  ggplot2  = "4.0.0",     # required for ggtree >= 3.99.0
-  ggiraph  = "0.9.1",     # required for ggtree dev
-  fgsea    = NA,          # Bioc package, any version is ok
-  ggtree   = NA           # dev version, skip version check
-)
-
-for (pkg in names(required)) {
-  if (!pkg %in% rownames(ip)) {
-    stop("❌ Package ", pkg, " is not installed in ", user_lib,
-         ". Please re-run install.R earlier steps.")
-  }
-  target_ver <- required[[pkg]]
-  if (!is.na(target_ver)) {
-    inst_ver <- ip[pkg, "Version"]
-    if (inst_ver != target_ver) {
-      stop("❌ Package ", pkg, " version mismatch: installed ", inst_ver,
-           " but expected ", target_ver)
-    }
-  }
-}
-
-message("✅ Core graphics stack verified. Proceeding with Bioconductor install…")
+# # --- Sanity check core graphics stack before Bioconductor ---
+# ip <- installed.packages(lib.loc = user_lib)
+# 
+# required <- list(
+#   BH       = "1.81.0-1",  # pinned because fgsea needs <=1.81
+#   ggplot2  = "4.0.0",     # required for ggtree >= 3.99.0
+#   ggiraph  = "0.9.1",     # required for ggtree dev
+#   fgsea    = NA,          # Bioc package, any version is ok
+#   ggtree   = NA           # dev version, skip version check
+# )
+# 
+# for (pkg in names(required)) {
+#   if (!pkg %in% rownames(ip)) {
+#     stop("❌ Package ", pkg, " is not installed in ", user_lib,
+#          ". Please re-run install.R earlier steps.")
+#   }
+#   target_ver <- required[[pkg]]
+#   if (!is.na(target_ver)) {
+#     inst_ver <- ip[pkg, "Version"]
+#     if (inst_ver != target_ver) {
+#       stop("❌ Package ", pkg, " version mismatch: installed ", inst_ver,
+#            " but expected ", target_ver)
+#     }
+#   }
+# }
+# 
+# message("✅ Core graphics stack verified. Proceeding with Bioconductor install…")
 
 # --- Bioconductor 3.18 ---
 BiocManager::install(version = "3.18", ask = FALSE)
 
+# Explicitly install fgsea first (critical dep)
+BiocManager::install("fgsea", lib = user_lib, ask = FALSE, update = FALSE)
 
 # Core Bioconductor packages
 BiocManager::install(c(

--- a/.devcontainer/install.R
+++ b/.devcontainer/install.R
@@ -5,11 +5,18 @@ if (!dir.exists(user_lib)) {
 }
 .libPaths(c(user_lib, .libPaths()))
 
-options(repos = c(CRAN = "https://cloud.r-project.org"))
+options(
+  repos = c(CRAN = "https://cloud.r-project.org"),
+  install.packages.check.source = "no"  # don’t “update” to source if binary differs
+)
+Sys.setenv(R_REMOTES_NO_ERRORS_FROM_WARNINGS = "true")
 
-# --- Bootstrap remotes ---
+# --- Bootstrap remotes + BiocManager ---
 if (!requireNamespace("remotes", quietly = TRUE)) {
   install.packages("remotes", lib = user_lib, repos = "https://cloud.r-project.org")
+}
+if (!requireNamespace("BiocManager", quietly = TRUE)) {
+  install.packages("BiocManager", lib = user_lib, repos = "https://cloud.r-project.org")
 }
 
 # --- Pin critical versions ---
@@ -30,25 +37,21 @@ remotes::install_version(
   type = "source"
 )
 
-# --- BiocManager for Bioconductor installs ---
-if (!requireNamespace("BiocManager", quietly = TRUE)) {
-  install.packages("BiocManager", lib = user_lib, repos = "https://cloud.r-project.org")
-}
-
-# --- Upgrade ggiraph (>=0.9.1 required for ggtree dev) ---
+# --- Pin CRAN critical versions ---
+remotes::install_version("BH", version = "1.81.0-1", lib = user_lib, repos = "https://cloud.r-project.org", type = "source")
+remotes::install_version("ggplot2", version = "4.0.0", lib = user_lib, repos = "https://cloud.r-project.org", type = "source")
 remotes::install_version("ggiraph", version = "0.9.1", lib = user_lib, repos = "https://cloud.r-project.org")
 
-# --- Install ggtree from GitHub (latest dev release) ---
+# --- Install ggtree (dev version, requires pinned deps) ---
 remotes::install_github("YuLab-SMU/ggtree", lib = user_lib, upgrade = "never")
 
-message("✅ Test environment ready with BH 1.81.0-1, ggplot2 4.0.0, and ggtree 3.99.0")
-
-
-
-# Install devtools (needed for devtools::test)
+# --- Install devtools ---
 install.packages("devtools", lib = user_lib, repos = "https://cloud.r-project.org")
 
+
 message("✅ Core graphics stack ready: BH 1.81.0-1, ggplot2 4.0.0, ggiraph 0.9.1 ggtree 3.99.0")
+
+
 
 # --- CRAN core deps (without full tidyverse) ---
 install.packages(c(
@@ -58,8 +61,38 @@ install.packages(c(
   "Rcpp", "RcppAnnoy", "RcppProgress", "uwot"
 ), lib = user_lib)
 
+
+# --- Sanity check core graphics stack before Bioconductor ---
+ip <- installed.packages(lib.loc = user_lib)
+
+required <- list(
+  BH       = "1.81.0-1",  # pinned because fgsea needs <=1.81
+  ggplot2  = "4.0.0",     # required for ggtree >= 3.99.0
+  ggiraph  = "0.9.1",     # required for ggtree dev
+  fgsea    = NA,          # Bioc package, any version is ok
+  ggtree   = NA           # dev version, skip version check
+)
+
+for (pkg in names(required)) {
+  if (!pkg %in% rownames(ip)) {
+    stop("❌ Package ", pkg, " is not installed in ", user_lib,
+         ". Please re-run install.R earlier steps.")
+  }
+  target_ver <- required[[pkg]]
+  if (!is.na(target_ver)) {
+    inst_ver <- ip[pkg, "Version"]
+    if (inst_ver != target_ver) {
+      stop("❌ Package ", pkg, " version mismatch: installed ", inst_ver,
+           " but expected ", target_ver)
+    }
+  }
+}
+
+message("✅ Core graphics stack verified. Proceeding with Bioconductor install…")
+
 # --- Bioconductor 3.18 ---
 BiocManager::install(version = "3.18", ask = FALSE)
+
 
 # Core Bioconductor packages
 BiocManager::install(c(


### PR DESCRIPTION
### Description
This PR introduces a complete .devcontainer/ environment for reproducible development in GitHub Codespaces and local devcontainers.

#### Key changes
.devcontainer/Dockerfile

- Based on rocker/r-ver:4.3.3 for stable R environment
- Installs essential system dependencies (build-essential, libbz2-dev, libcurl4-openssl-dev, zlib1g-dev, etc.) needed for compiling R packages
- Avoids broken packages (libhts-dev) that cause dependency conflicts on Ubuntu Jammy

.devcontainer/devcontainer.json

- Defines workspace container configuration
- Ensures R environment and tooling are set up automatically after container creation
- Runs install.R as postStartCommand to bootstrap all R dependencies

.devcontainer/install.R

- Creates and pins a dedicated user R library ($R_LIBS_USER)
- Pins critical versions for graphics and Bioconductor compatibility:
   - BH 1.81.0-1 (required by fgsea)
   - ggplot2 4.0.0, ggiraph 0.9.1 (required by ggtree dev version)
- Installs ggtree from GitHub (YuLab-SMU/ggtree)
- Installs devtools for local testing (devtools::test)
- Bootstraps Bioconductor 3.18 and installs core packages (IRanges, GenomicRanges, SummarizedExperiment, etc.)
- Installs critical analysis libraries (qsea, fgsea, clusterProfiler, ChIPseeker, ReactomePA, MEDIPS, etc.)
- Adds extra runtime/test dependencies (plyranges, ComplexHeatmap, biomaRt, circlize, pheatmap, janitor, hues)


#### Main issues to fix:

- Version mismatches (e.g., BH >= 1.82 breaking fgsea)
- OS-level dependency conflicts (libhts-dev not installable)
- Packages requiring pinned versions for dev versions (ggtree)

This PR solves these issues by centralizing all setup in .devcontainer/ so that any developer opening the project in Codespaces gets a working R environment automatically.
