### PR TITLE
fix: resolve pkgdown deployment failure on GitHub Actions

### DIFF
--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -77,7 +77,15 @@ jobs:
       ## https://github.com/r-lib/actions/blob/master/examples/check-standard.yaml
       ## If they update their steps, we will also need to update ours.
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+
+      - name: System info
+        run: |
+          echo "Git version: $(git --version)"
+          echo "Runner OS: $RUNNER_OS"
+          echo "Runner image: $ImageVersion"
+          echo "Workspace owner: $(stat -c '%U' $GITHUB_WORKSPACE)"
+          echo "Current user: $(whoami)"
 
       ## R is already included in the Bioconductor docker images
       - name: Setup R from r-lib
@@ -196,13 +204,13 @@ jobs:
         shell: Rscript {0}
 
       - name: Install covr
-        if: github.ref == 'refs/heads/main' && env.run_covr == 'true' && runner.os == 'Linux'
+        if: github.ref == 'refs/heads/deploy_package_action_fix' && env.run_covr == 'true' && runner.os == 'Linux'
         run: |
           remotes::install_cran("covr")
         shell: Rscript {0}
 
       - name: Install pkgdown
-        if: github.ref == 'refs/heads/main' && env.run_pkgdown == 'true' && runner.os == 'Linux'
+        if: github.ref == 'refs/heads/deploy_package_action_fix' && env.run_pkgdown == 'true' && runner.os == 'Linux'
         run: |
           remotes::install_cran("pkgdown")
         shell: Rscript {0}
@@ -248,17 +256,17 @@ jobs:
         shell: Rscript {0}
 
       - name: Test coverage
-        if: github.ref == 'refs/heads/main' && env.run_covr == 'true' && runner.os == 'Linux'
+        if: github.ref == 'refs/heads/deploy_package_action_fix' && env.run_covr == 'true' && runner.os == 'Linux'
         run: |
           covr::codecov()
         shell: Rscript {0}
 
       - name: Install package
-        if: github.ref == 'refs/heads/main' && env.run_pkgdown == 'true' && runner.os == 'Linux'
+        if: github.ref == 'refs/heads/deploy_package_action_fix' && env.run_pkgdown == 'true' && runner.os == 'Linux'
         run: R CMD INSTALL .
 
       - name: Deploy package
-        if: github.ref == 'refs/heads/main' && env.run_pkgdown == 'true' && runner.os == 'Linux'
+        if: github.ref == 'refs/heads/deploy_package_action_fix' && env.run_pkgdown == 'true' && runner.os == 'Linux'
         run: |
           git config --global --add safe.directory /__w/mesa/mesa
           git config --local user.email "actions@github.com"

--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -204,13 +204,13 @@ jobs:
         shell: Rscript {0}
 
       - name: Install covr
-        if: github.ref == 'refs/heads/deploy_package_action_fix' && env.run_covr == 'true' && runner.os == 'Linux'
+        if: github.ref == 'refs/heads/main' && env.run_covr == 'true' && runner.os == 'Linux'
         run: |
           remotes::install_cran("covr")
         shell: Rscript {0}
 
       - name: Install pkgdown
-        if: github.ref == 'refs/heads/deploy_package_action_fix' && env.run_pkgdown == 'true' && runner.os == 'Linux'
+        if: github.ref == 'refs/heads/main' && env.run_pkgdown == 'true' && runner.os == 'Linux'
         run: |
           remotes::install_cran("pkgdown")
         shell: Rscript {0}
@@ -256,17 +256,17 @@ jobs:
         shell: Rscript {0}
 
       - name: Test coverage
-        if: github.ref == 'refs/heads/deploy_package_action_fix' && env.run_covr == 'true' && runner.os == 'Linux'
+        if: github.ref == 'refs/heads/main' && env.run_covr == 'true' && runner.os == 'Linux'
         run: |
           covr::codecov()
         shell: Rscript {0}
 
       - name: Install package
-        if: github.ref == 'refs/heads/deploy_package_action_fix' && env.run_pkgdown == 'true' && runner.os == 'Linux'
+        if: github.ref == 'refs/heads/main' && env.run_pkgdown == 'true' && runner.os == 'Linux'
         run: R CMD INSTALL .
 
       - name: Deploy package
-        if: github.ref == 'refs/heads/deploy_package_action_fix' && env.run_pkgdown == 'true' && runner.os == 'Linux'
+        if: github.ref == 'refs/heads/main' && env.run_pkgdown == 'true' && runner.os == 'Linux'
         run: |
           git config --global --add safe.directory /__w/mesa/mesa
           git config --local user.email "actions@github.com"

--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -260,6 +260,7 @@ jobs:
       - name: Deploy package
         if: github.ref == 'refs/heads/main' && env.run_pkgdown == 'true' && runner.os == 'Linux'
         run: |
+          git config --global --add safe.directory /__w/mesa/mesa
           git config --local user.email "actions@github.com"
           git config --local user.name "GitHub Actions"
           Rscript -e "pkgdown::deploy_to_branch(new_process = FALSE)"

--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,7 @@ editor_options:
 * `plotPCA` and `plotUMAP` no longer take the `qseaSet` as an input. The PCA/UMAP object has a copy of the `sampleTable` which may be modified instead. [!58](https://github.com/cruk-mi/mesa/pull/58)
 * Swapped to use of `seq_along` rather than `1:n` throughout. [!67](https://github.com/cruk-mi/mesa/pull/67)
 * Be more specific in the use of message suppression. [!66](https://github.com/cruk-mi/mesa/pull/66)
+* Updated `actions/checkout@v2` to `v4`; added system info step to CI for easier debugging. [!71](https://github.com/cruk-mi/mesa/pull/71)
 
 ### REMOVED
 * Made `plotGenomicFeatureDistribution` and `getGenomicFeatureDistribution` internal as they currently only work for hg38. [!14](https://github.com/cruk-mi/mesa/pull/14)
@@ -36,6 +37,7 @@ editor_options:
 * Removed internal functions`getAnnotationDataFrame` and `getAnnotationDataFrameIndividual` as they are superseded by `getAnnotation` and the shift to tidy evaluation via `sampleAnnotation` in the plotting functions. [!14](https://github.com/cruk-mi/mesa/pull/14)
 * Removed `colnames` function definion on a qseaSet, which was not working anyway. [!14](https://github.com/cruk-mi/mesa/pull/14)
 * Removed `dropAvgFragDetails` as no longer required. [!63](https://github.com/cruk-mi/mesa/pull/63)
+* Removed GitLab CI files; updated `.Rbuildignore` to exclude `.github`, `.devcontainer`, `docs/` and other non-package files from the build — silences related `R CMD check` notes. [!70](https://github.com/cruk-mi/mesa/pull/70)
 
 ### BUG FIXES
 * `makeTransposedTable` no longer adds `chr` to the window names even if they already had a `chr` prefix. [!14](https://github.com/cruk-mi/mesa/pull/14)
@@ -55,6 +57,8 @@ editor_options:
 * Fixed GRanges conversion error in `plotGenomicFeatureDistribution` that occurred with Bioconductor 3.21 when multiple chromosome columns existed after ChIPseeker annotation. [!68](https://github.com/cruk-mi/mesa/pull/68)
 * Fixed makeQset validation tests to handle updated annotation database versions and focus on parameter validation rather than computational integration tests. [!68](https://github.com/cruk-mi/mesa/pull/68)
 * Updated network error patterns in testPlotGeneHeatmap, preventing biomart HTP 503 error in test-makeQset.R:83:3. [!68](https://github.com/cruk-mi/mesa/pull/68)
+* Fixed `plotGeneHeatmap()` examples to handle transient Ensembl connection errors during `R CMD check`. [!70](https://github.com/cruk-mi/mesa/pull/70)
+* Fixed pkgdown deployment failure on GitHub Actions caused by git ownership mismatch in Docker containers. [!71](https://github.com/cruk-mi/mesa/pull/71)
 
 # mesa 0.5.1
 


### PR DESCRIPTION
## Summary
The pkgdown deployment step was failing on push to main due to a git
ownership error when running inside the Bioconductor Docker container.
This PR fixes the deployment and modernises the CI setup.

## Problem
The deploy step was failing with:

`fatal: detected dubious ownership in repository at '/__w/mesa/mesa'`

The runner uses git 2.34.1 (confirmed via system info step), which
predates the git 2.35.2 ownership check. The root cause is
actions/checkout@v2 having known ownership issues when running inside
a Docker container — the workspace is checked out by the host runner
but the job executes inside the container as a different user.

## Changes

### fix: add safe.directory config before pkgdown deploy
- Defensive fix for the ownership mismatch between host runner and
  Docker container user
- Scoped to the same conditions as the deploy step

### ci: update actions/checkout and add system info step  
- `actions/checkout@v2` → `v4`: the primary fix — v4 handles
  workspace ownership correctly in containerised environments
- Add system info step to expose git version, runner image, workspace
  ownership and current user — this is what revealed git 2.34.1 and
  helped diagnose the real root cause

## Testing
- Tested on `deploy_package_action_fix` branch
- System info step output confirmed git 2.34.1, ruling out the
  git >= 2.35.2 ownership check as root cause

## Notes
- No R code or package behaviour changes in this PR