### PR TITLE
[0.99.2] Fixes the TIMEOUT in R CMD check reported by the Bioconductor Single Package Builder.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mesa
 Title: Methylation Enrichment Sequencing Analysis
-Version: 0.99.1
+Version: 0.99.2
 Authors@R: c(
     person(given = "Simon",
            family = "Pearce",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,3 @@
----
-editor_options: 
-  markdown: 
-    wrap: sentence
----
-
 # mesa 0.99.2
 
 ### BUG FIXES

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,20 @@ editor_options:
     wrap: sentence
 ---
 
+# mesa 0.99.2
+
+### BUG FIXES
+* Wrapped slow examples (>5 s) in `\donttest{}` across `getPCA()`, `getUMAP()`,
+  `getDimRed()`, `plotUMAP()`, `plotDimRed()`, `makeQset()`, `annotateWindows()`,
+  `getGenomicFeatureDistribution()`, `plotRegionsHeatmap()`, `plotGeneHeatmap()`,
+  `plotGenomicFeatureDistribution()`, `summariseDMRsByGene()`, `writeDMRsToExcel()`,
+  `writeDMRsToBed()`, and `calculateCGEnrichmentGRanges()` — fixes R CMD check
+  TIMEOUT on Bioconductor build machines.
+  ([#74](https://github.com/cruk-mi/mesa/pull/74))
+* Removed duplicate `@examples` block in `plotRegionsHeatmap()` that caused
+  identical examples to appear twice in the generated Rd file.
+  ([#74](https://github.com/cruk-mi/mesa/pull/74))
+
 # mesa 0.99.1
 
 * Fixed Rd cross-references to use `\code{\link[pkg]{function}}` syntax —

--- a/R/PCA.R
+++ b/R/PCA.R
@@ -5,6 +5,7 @@
 #' @describeIn getDimRed Principal component analysis of a qseaSet.
 #' @family dimred-helpers
 #' @examples
+#' \donttest{
 #' data(exampleTumourNormal, package = "mesa")
 #'
 #' # Default PCA (beta-normalised, top 1000 most variable windows, 5 PCs)
@@ -20,6 +21,7 @@
 #'   getPCA(topVarNum = c(10, 100, 500, NA)) %>%
 #'   slot("res") %>%
 #'   names()
+#' }
 #' @export
 getPCA <- function(qseaSet,
                    dataTable = NULL,
@@ -62,6 +64,7 @@ getPCA <- function(qseaSet,
 #' @describeIn getDimRed Uniform manifold approximation and projection of a qseaSet.
 #' @family dimred-helpers
 #' @examples
+#' \donttest{
 #' # Quick demo on a small synthetic qseaSet
 #' qsea::getExampleQseaSet(repl = 20) %>%
 #'   getUMAP()
@@ -73,6 +76,7 @@ getPCA <- function(qseaSet,
 #' # Use top 500 most variable windows only
 #' qsea::getExampleQseaSet(repl = 20) %>%
 #'   getUMAP(topVarNum = 500)
+#' }
 #' @export
 getUMAP <- function(qseaSet,
                    dataTable = NULL,
@@ -208,6 +212,7 @@ getUMAP <- function(qseaSet,
 #' @family dimred-helpers
 #'
 #' @examples
+#' \donttest{
 #' data(exampleTumourNormal, package = "mesa")
 #'
 #' # PCA on default beta-normalised matrix, keep 3 PCs
@@ -228,6 +233,7 @@ getUMAP <- function(qseaSet,
 #'   getDimRed(method = "UMAP", topVarNum = c(500, 2000), n_neighbors = 5) %>%
 #'   slot("res") %>%
 #'   names()
+#' }
 #' @export
 getDimRed <- function(qseaSet,
                       dataTable = NULL,
@@ -1185,6 +1191,7 @@ plotPCA.mesaDimRed <- function(object,
 #' @family dimred-helpers
 #'
 #' @examples
+#' \donttest{
 #' data(exampleTumourNormal, package = "mesa")
 #'
 #' # Default UMAP (beta-normalised, top 1000 most variable windows)
@@ -1204,6 +1211,7 @@ plotPCA.mesaDimRed <- function(object,
 #'   plotUMAP(components = list(c(1, 2)),
 #'            colour = "group",
 #'            shape  = "tissue")
+#' }
 #'
 #' @export
 plotUMAP <- function(object,
@@ -1319,6 +1327,7 @@ plotUMAP <- function(object,
 #' @family dimred-helpers
 #'
 #' @examples
+#' \donttest{
 #' data(exampleTumourNormal, package = "mesa")
 #'
 #' # PCA: colour by group
@@ -1337,6 +1346,7 @@ plotUMAP <- function(object,
 #'   getPCA(nPC = 3) %>%
 #'   plotDimRed(colour = "group",
 #'              showSampleNames = TRUE) 
+#' }
 #'
 #' @export
 plotDimRed <- function(object,

--- a/R/analyseDMRs.R
+++ b/R/analyseDMRs.R
@@ -174,6 +174,7 @@ summariseDMRsByContrast <- function(DMRtable, FDRthres = 0.05, log2FCthres = 0, 
 #' @family DMR-helpers
 #'
 #' @examples
+#' \donttest{
 #' data(exampleTumourNormal, package = "mesa")
 #'
 #' # Summarise DMRs with explicit annotation databases
@@ -182,6 +183,7 @@ summariseDMRsByContrast <- function(DMRtable, FDRthres = 0.05, log2FCthres = 0, 
 #'   annotateWindows(TxDb = "TxDb.Hsapiens.UCSC.hg38.knownGene",
 #'                   annoDb = "org.Hs.eg.db") %>%
 #'   summariseDMRsByGene()
+#' }
 #' @export
 summariseDMRsByGene <- function(DMRtable){
 
@@ -234,6 +236,7 @@ summariseDMRsByGene <- function(DMRtable){
 #' @family DMR-helpers
 #'
 #' @examples
+#' \donttest{
 #' data(exampleTumourNormal, package = "mesa")
 #'
 #' # Minimal example: write results for a single contrast
@@ -246,6 +249,7 @@ summariseDMRsByGene <- function(DMRtable){
 #'   calculateDMRs(variable = "tumour", contrasts = "all") %>%
 #'   annotateWindows(TxDb = "TxDb.Hsapiens.UCSC.hg38.knownGene", annoDb = "org.Hs.eg.db") %>%
 #'   writeDMRsToExcel(path = file.path(tempdir(),"test.xlsx"))
+#' }
 #' @export
 writeDMRsToExcel <- function(dataTable, path, FDRthres = 0.05) {
 
@@ -308,6 +312,7 @@ writeDMRsToExcel <- function(dataTable, path, FDRthres = 0.05) {
 #' @family DMR-helpers
 #'
 #' @examples
+#' \donttest{
 #' data(exampleTumourNormal, package = "mesa")
 #'
 #' # Export DMRs for a single contrast to BED files in a temp directory
@@ -322,6 +327,7 @@ writeDMRsToExcel <- function(dataTable, path, FDRthres = 0.05) {
 #'   annotateWindows(TxDb = "TxDb.Hsapiens.UCSC.hg38.knownGene",
 #'                   annoDb = "org.Hs.eg.db") %>%
 #'   writeDMRsToBed(folder = tempdir(), FDRthres = 0.1)
+#' }
 #' @export
 writeDMRsToBed <- function(dataTable, folder, FDRthres = 0.05) {
 

--- a/R/calculateEnrichment.R
+++ b/R/calculateEnrichment.R
@@ -306,6 +306,7 @@ getCGPositions <- function(BSgenome, chr.select){
 #'   \pkg{BSgenome}
 #'
 #' @examples
+#' \donttest{
 #' # Runnable toy example with synthetic reads over chr1 (requires a BSgenome)
 #' if (requireNamespace("BSgenome.Hsapiens.NCBI.GRCh38", quietly = TRUE)) {
 #'   n <- 200
@@ -322,6 +323,7 @@ getCGPositions <- function(BSgenome, chr.select){
 #'     BSgenome    = "BSgenome.Hsapiens.NCBI.GRCh38",
 #'     chr.select  = 1
 #'   )
+#' }
 #' }
 #' @export
 calculateCGEnrichmentGRanges <- function(readGRanges = NULL, BSgenome = NULL, chr.select = NULL){

--- a/R/makeQset.R
+++ b/R/makeQset.R
@@ -177,6 +177,7 @@
 #' [addHMMcopyCNV()], [setMesaParallel()], [BSgenome::available.genomes()]
 #'
 #' @examples
+#' \donttest{
 #' # Minimal runnable sketch if MEDIPSData is installed
 #' if (requireNamespace("MEDIPSData", quietly = TRUE)) {
 #'   sampleTable <- data.frame(
@@ -202,6 +203,7 @@
 #'       properPairsOnly   = FALSE,
 #'       minMapQual        = 10
 #'     )
+#' }
 #' }
 #' @export
 makeQset <- function(sampleTable,

--- a/R/plotting.R
+++ b/R/plotting.R
@@ -93,6 +93,7 @@
 #' [calculateDMRs()], [getSampleTable()], [getWindows()]
 #'
 #' @examples
+#' \donttest{
 #' data(exampleTumourNormal, package = "mesa")
 #' 
 #' # Compute regions (DMRs) to plot
@@ -116,28 +117,8 @@
 #'                    windowAnnotation = CpG_density,
 #'                    annotationColors = list(tumour = c("Tumour" = "firebrick4", "Normal" = "blue"))
 #'                     )
-#' 
+#' }
 #' @export
-#' @examples
-#' # calculate DMRs to plot
-#' DMRs <- exampleTumourNormal %>% calculateDMRs(variable = "tumour", contrasts = "first")
-#' # plot these windows
-#' exampleTumourNormal %>% plotRegionsHeatmap(DMRs)
-#' # cluster the rows and add annotation
-#' exampleTumourNormal %>% plotRegionsHeatmap(DMRs, 
-#'                                            clusterRows = TRUE, 
-#'                                            sampleAnnotation = c(tumour, tissue)
-#'                                            )
-#' # more complex example
-#' exampleTumourNormal %>% 
-#'   plotRegionsHeatmap(regionsToOverlap = DMRs, 
-#'                    clusterRows = TRUE, 
-#'                    clusterNum = 2,
-#'                    sampleAnnotation = tumour,
-#'                    windowAnnotation = CpG_density,
-#'                    annotationColors = list(tumour = c("Tumour" = "firebrick4", "Normal" = "blue"))
-#'                     )
-#' 
 plotRegionsHeatmap <- function(qseaSet, regionsToOverlap = NULL,
                                 normMethod = "beta",
                                 sampleAnnotation = NULL,
@@ -734,6 +715,7 @@ makeHeatmapAnnotations <- function(qseaSet,
 #' [biomaRt::useMart()], [ComplexHeatmap::Heatmap()]
 #'
 #' @examples
+#' \donttest{
 #' data(exampleTumourNormal, package = "mesa")
 #'
 #' # Basic gene heatmap (beta) with defaults
@@ -761,6 +743,7 @@ makeHeatmapAnnotations <- function(qseaSet,
 #'                     downstreamDist = 2000),
 #'   error = function(e) message("Ensembl unavailable: ", conditionMessage(e))
 #' )
+#' }
 #'
 #' @export
 plotGeneHeatmap <- function(qseaSet, gene, normMethod = "beta",
@@ -1170,6 +1153,7 @@ makeGeneHeatmapRowAnnotation <- function(rowAnnotationDF){
 #' @family annotation-summaries
 #'
 #' @examples
+#' \donttest{
 #' # Recommended workflow: set genome globally
 #' setMesaGenome("hg38") 
 #' data(exampleTumourNormal, package = "mesa")
@@ -1188,6 +1172,7 @@ makeGeneHeatmapRowAnnotation <- function(rowAnnotationDF){
 #'     TxDb = TxDb.Mmusculus.UCSC.mm10.knownGene::TxDb.Mmusculus.UCSC.mm10.knownGene,
 #'     annoDb = "org.Mm.eg.db"
 #'   )
+#' }
 #'   
 #' @export
 plotGenomicFeatureDistribution <- function(qseaSet, cutoff = 1, barType = "stack", 

--- a/R/qseaExtra.R
+++ b/R/qseaExtra.R
@@ -156,6 +156,7 @@ setMethod('getMart', 'qseaSet', function(object) object@parameters$mart)
 #' [qseaTableToChrGRanges()], [liftOverHg19()]
 #'
 #' @examples
+#' \donttest{
 #' data(exampleTumourNormal, package = "mesa")
 #'
 #' # Derive some regions (e.g., DMRs) then annotate using GRCh38 defaults
@@ -184,6 +185,7 @@ setMethod('getMart', 'qseaSet', function(object) object@parameters$mart)
 #'   setMesaGenome("hg38"); 
 #'   setMesaTxDb("TxDb.Hsapiens.UCSC.hg38.knownGene"); 
 #'   setMesaAnnoDb("org.Hs.eg.db")
+#' }
 #'
 #' @export
 annotateWindows <- function(dataTable, genome = .getMesaGenome(), TxDb = .getMesaTxDb(), 
@@ -1554,6 +1556,7 @@ addSummaryAcrossWindows <- function(qseaSet,
 #' @family annotation-summaries
 #'
 #' @examples
+#' \donttest{
 #' # Ensure annotation defaults are available (GRCh38/hg38)
 #' setMesaGenome("hg38")
 #'
@@ -1568,6 +1571,7 @@ addSummaryAcrossWindows <- function(qseaSet,
 #' exampleTumourNormal %>%
 #'   getGenomicFeatureDistribution(cutoff = 0.7, normMethod = "beta", minEnrichment = 3) %>%
 #'   head()
+#' }
 #'
 #' @export
 getGenomicFeatureDistribution <- function(qseaSet, cutoff = 1 , normMethod = "nrpm", minEnrichment = 3){

--- a/man/addHMMcopyCNV.Rd
+++ b/man/addHMMcopyCNV.Rd
@@ -95,7 +95,7 @@ When \code{parallel = TRUE}, computation uses the currently registered backend
 (see \code{BiocParallel::register()}).
 }
 \examples{
-\dontrun{
+\donttest{
 data(exampleTumourNormal, package = "mesa")
 exampleTumourNormal \%>\%
 

--- a/man/addMedipsEnrichmentFactors.Rd
+++ b/man/addMedipsEnrichmentFactors.Rd
@@ -82,7 +82,7 @@ then merges the results into the \verb{@libraries} slot (\verb{$file_name} for p
 \code{parallel::mclapply()}; on non-Unix systems, \code{nCores} > 1 is ignored.
 }
 \examples{
-\dontrun{
+\donttest{
  if (requireNamespace("MEDIPS", quietly = TRUE) &&
     requireNamespace("BSgenome.Hsapiens.UCSC.hg19", quietly = TRUE)) {
       

--- a/man/annotateWindows.Rd
+++ b/man/annotateWindows.Rd
@@ -71,6 +71,7 @@ trailing parenthetical), and—when contexts are provided—\code{landscape}
 }
 }
 \examples{
+\donttest{
 data(exampleTumourNormal, package = "mesa")
 
 # Derive some regions (e.g., DMRs) then annotate using GRCh38 defaults
@@ -99,6 +100,7 @@ exampleMouse \%>\%
   setMesaGenome("hg38"); 
   setMesaTxDb("TxDb.Hsapiens.UCSC.hg38.knownGene"); 
   setMesaAnnoDb("org.Hs.eg.db")
+}
 
 }
 \seealso{

--- a/man/calculateCGEnrichmentGRanges.Rd
+++ b/man/calculateCGEnrichmentGRanges.Rd
@@ -49,6 +49,7 @@ Unlike \code{\link[=calculateCGEnrichment]{calculateCGEnrichment()}}, this funct
 summarised as genomic ranges.
 }
 \examples{
+\donttest{
 # Runnable toy example with synthetic reads over chr1 (requires a BSgenome)
 if (requireNamespace("BSgenome.Hsapiens.NCBI.GRCh38", quietly = TRUE)) {
   n <- 200
@@ -65,6 +66,7 @@ if (requireNamespace("BSgenome.Hsapiens.NCBI.GRCh38", quietly = TRUE)) {
     BSgenome    = "BSgenome.Hsapiens.NCBI.GRCh38",
     chr.select  = 1
   )
+}
 }
 }
 \seealso{

--- a/man/getDimRed.Rd
+++ b/man/getDimRed.Rd
@@ -173,6 +173,7 @@ are performed and collected in \code{res}.
 
 }}
 \examples{
+\donttest{
 data(exampleTumourNormal, package = "mesa")
 
 # Default PCA (beta-normalised, top 1000 most variable windows, 5 PCs)
@@ -188,6 +189,8 @@ exampleTumourNormal \%>\%
   getPCA(topVarNum = c(10, 100, 500, NA)) \%>\%
   slot("res") \%>\%
   names()
+}
+\donttest{
 # Quick demo on a small synthetic qseaSet
 qsea::getExampleQseaSet(repl = 20) \%>\%
   getUMAP()
@@ -199,6 +202,8 @@ qsea::getExampleQseaSet(repl = 20) \%>\%
 # Use top 500 most variable windows only
 qsea::getExampleQseaSet(repl = 20) \%>\%
   getUMAP(topVarNum = 500)
+}
+\donttest{
 data(exampleTumourNormal, package = "mesa")
 
 # PCA on default beta-normalised matrix, keep 3 PCs
@@ -219,6 +224,7 @@ exampleTumourNormal \%>\%
   getDimRed(method = "UMAP", topVarNum = c(500, 2000), n_neighbors = 5) \%>\%
   slot("res") \%>\%
   names()
+}
 }
 \seealso{
 \code{\link[=getPCA]{getPCA()}}, \code{\link[=getUMAP]{getUMAP()}}, \linkS4class{mesaDimRed}, \linkS4class{mesaPCA}, \linkS4class{mesaUMAP},

--- a/man/getGenomicFeatureDistribution.Rd
+++ b/man/getGenomicFeatureDistribution.Rd
@@ -59,6 +59,7 @@ This function requires a transcript database and OrgDb to annotate windows (via
 }
 }
 \examples{
+\donttest{
 # Ensure annotation defaults are available (GRCh38/hg38)
 setMesaGenome("hg38")
 
@@ -73,6 +74,7 @@ exampleTumourNormal \%>\%
 exampleTumourNormal \%>\%
   getGenomicFeatureDistribution(cutoff = 0.7, normMethod = "beta", minEnrichment = 3) \%>\%
   head()
+}
 
 }
 \seealso{

--- a/man/makeQset.Rd
+++ b/man/makeQset.Rd
@@ -220,6 +220,7 @@ enrichment parameters, allowing for estimation of beta values.
 }
 }
 \examples{
+\donttest{
 # Minimal runnable sketch if MEDIPSData is installed
 if (requireNamespace("MEDIPSData", quietly = TRUE)) {
   sampleTable <- data.frame(
@@ -245,6 +246,7 @@ if (requireNamespace("MEDIPSData", quietly = TRUE)) {
       properPairsOnly   = FALSE,
       minMapQual        = 10
     )
+}
 }
 }
 \seealso{

--- a/man/mixThreeQsetSamples.Rd
+++ b/man/mixThreeQsetSamples.Rd
@@ -86,7 +86,7 @@ on offsets/enrichment being recomputed.
 }
 }
 \examples{
-\dontrun{
+\donttest{
 data(exampleTumourNormal, package = "mesa")
 
 # Mix three samples 50/30/20 into ~100k total fragments; append to the qseaSet

--- a/man/plotDimRed.Rd
+++ b/man/plotDimRed.Rd
@@ -108,6 +108,7 @@ Wrappers such as \code{\link[BiocGenerics:plotPCA]{BiocGenerics::plotPCA()}} and
 for common use cases.
 }
 \examples{
+\donttest{
 data(exampleTumourNormal, package = "mesa")
 
 # PCA: colour by group
@@ -126,6 +127,7 @@ exampleTumourNormal \%>\%
   getPCA(nPC = 3) \%>\%
   plotDimRed(colour = "group",
              showSampleNames = TRUE) 
+}
 
 }
 \seealso{

--- a/man/plotGeneHeatmap.Rd
+++ b/man/plotGeneHeatmap.Rd
@@ -118,6 +118,7 @@ aggregated by \code{group} prior to plotting. Column annotations can be added vi
 \code{sampleAnnotation}; colours can be customized via \code{annotationColors}.
 }
 \examples{
+\donttest{
 data(exampleTumourNormal, package = "mesa")
 
 # Basic gene heatmap (beta) with defaults
@@ -145,6 +146,7 @@ tryCatch(
                     downstreamDist = 2000),
   error = function(e) message("Ensembl unavailable: ", conditionMessage(e))
 )
+}
 
 }
 \seealso{

--- a/man/plotGenomicFeatureDistribution.Rd
+++ b/man/plotGenomicFeatureDistribution.Rd
@@ -57,6 +57,7 @@ Feature classes are taken from region annotations available on the windows
 if present). Bars are positioned according to \code{barType} (\code{stack}/\code{dodge}/\code{fill}).
 }
 \examples{
+\donttest{
 # Recommended workflow: set genome globally
 setMesaGenome("hg38") 
 data(exampleTumourNormal, package = "mesa")
@@ -75,6 +76,7 @@ exampleTumourNormal \%>\%
     TxDb = TxDb.Mmusculus.UCSC.mm10.knownGene::TxDb.Mmusculus.UCSC.mm10.knownGene,
     annoDb = "org.Mm.eg.db"
   )
+}
   
 }
 \seealso{

--- a/man/plotRegionsHeatmap.Rd
+++ b/man/plotRegionsHeatmap.Rd
@@ -117,6 +117,7 @@ For \code{"beta"}, low-enrichment values are set to \code{NA} using \code{minEnr
 samples are aggregated by \code{group} before plotting.
 }
 \examples{
+\donttest{
 data(exampleTumourNormal, package = "mesa")
 
 # Compute regions (DMRs) to plot
@@ -140,26 +141,7 @@ exampleTumourNormal \%>\%
                    windowAnnotation = CpG_density,
                    annotationColors = list(tumour = c("Tumour" = "firebrick4", "Normal" = "blue"))
                     )
-
-# calculate DMRs to plot
-DMRs <- exampleTumourNormal \%>\% calculateDMRs(variable = "tumour", contrasts = "first")
-# plot these windows
-exampleTumourNormal \%>\% plotRegionsHeatmap(DMRs)
-# cluster the rows and add annotation
-exampleTumourNormal \%>\% plotRegionsHeatmap(DMRs, 
-                                           clusterRows = TRUE, 
-                                           sampleAnnotation = c(tumour, tissue)
-                                           )
-# more complex example
-exampleTumourNormal \%>\% 
-  plotRegionsHeatmap(regionsToOverlap = DMRs, 
-                   clusterRows = TRUE, 
-                   clusterNum = 2,
-                   sampleAnnotation = tumour,
-                   windowAnnotation = CpG_density,
-                   annotationColors = list(tumour = c("Tumour" = "firebrick4", "Normal" = "blue"))
-                    )
-
+}
 }
 \seealso{
 \code{\link[qsea:makeTable]{qsea::makeTable()}}, \code{\link[ComplexHeatmap:Heatmap]{ComplexHeatmap::Heatmap()}}, \code{\link[ComplexHeatmap]{draw}},

--- a/man/plotUMAP.Rd
+++ b/man/plotUMAP.Rd
@@ -110,6 +110,7 @@ sample-level metadata, and can return multiple plots across UMAP component
 pairs and annotation variables.
 }
 \examples{
+\donttest{
 data(exampleTumourNormal, package = "mesa")
 
 # Default UMAP (beta-normalised, top 1000 most variable windows)
@@ -129,6 +130,7 @@ exampleTumourNormal \%>\%
   plotUMAP(components = list(c(1, 2)),
            colour = "group",
            shape  = "tissue")
+}
 
 }
 \seealso{

--- a/man/poolSamples.Rd
+++ b/man/poolSamples.Rd
@@ -39,7 +39,7 @@ combined by a weighted average using \code{total_fragments} from
 weighted means for rates).
 }
 \examples{
-\dontrun{
+\donttest{
 data(exampleTumourNormal, package = "mesa")
 # Pool Tumour/Normal pairs by patient into a single sample per patient:
 # e.g., "Colon1_T","Colon1_N" -> "Colon1"

--- a/man/runHMMCopy.Rd
+++ b/man/runHMMCopy.Rd
@@ -36,7 +36,7 @@ and returned as a \code{GRanges}. Ensure that the binning (\code{width}) and cov
 columns (\code{gc}, \code{map}) are consistent across the table.
 }
 \examples{
-\dontrun{
+\donttest{
 # Minimal synthetic example: build a table and pipe into runHMMCopy()
 set.seed(1)
 n <- 2000L; w <- 5e4

--- a/man/setMesaParallel.Rd
+++ b/man/setMesaParallel.Rd
@@ -59,7 +59,7 @@ setMesaParallel(useParallel = FALSE, verbose = FALSE)
 getMesaParallel()  # FALSE
 
 # --- Unix/mac (MulticoreParam): enable and use 2 cores ---
-\dontrun{
+\donttest{
 if (.Platform$OS.type != "windows") {
   old <- BiocParallel::bpparam()                         # save current backend
   setMesaParallel(nCores = 2, verbose = FALSE)           # registers MulticoreParam(2)
@@ -71,7 +71,7 @@ if (.Platform$OS.type != "windows") {
 }
 
 # --- Windows: register SnowParam yourself, then enable ---
-\dontrun{
+\donttest{
 if (.Platform$OS.type == "windows") {
   old <- BiocParallel::bpparam()
   BiocParallel::register(BiocParallel::SnowParam(workers = 2))

--- a/man/summariseDMRsByGene.Rd
+++ b/man/summariseDMRsByGene.Rd
@@ -22,6 +22,7 @@ associated DMRs and any aggregated metadata.
 Aggregate differentially methylated region (DMR) windows by gene annotation.
 }
 \examples{
+\donttest{
 data(exampleTumourNormal, package = "mesa")
 
 # Summarise DMRs with explicit annotation databases
@@ -30,6 +31,7 @@ exampleTumourNormal \%>\%
   annotateWindows(TxDb = "TxDb.Hsapiens.UCSC.hg38.knownGene",
                   annoDb = "org.Hs.eg.db") \%>\%
   summariseDMRsByGene()
+}
 }
 \seealso{
 \code{\link[=annotateWindows]{annotateWindows()}},

--- a/man/writeDMRsToBed.Rd
+++ b/man/writeDMRsToBed.Rd
@@ -30,6 +30,7 @@ Export differentially methylated region (DMR) results to a set of BED files,
 with one file generated per contrast.
 }
 \examples{
+\donttest{
 data(exampleTumourNormal, package = "mesa")
 
 # Export DMRs for a single contrast to BED files in a temp directory
@@ -44,6 +45,7 @@ exampleTumourNormal \%>\%
   annotateWindows(TxDb = "TxDb.Hsapiens.UCSC.hg38.knownGene",
                   annoDb = "org.Hs.eg.db") \%>\%
   writeDMRsToBed(folder = tempdir(), FDRthres = 0.1)
+}
 }
 \seealso{
 \code{\link[=writeDMRsToExcel]{writeDMRsToExcel()}}

--- a/man/writeDMRsToExcel.Rd
+++ b/man/writeDMRsToExcel.Rd
@@ -36,6 +36,7 @@ restricted on the system (e.g., some HPC build environments), consider
 writing to \code{tempfile(fileext = ".xlsx")} in examples or tests.
 }
 \examples{
+\donttest{
 data(exampleTumourNormal, package = "mesa")
 
 # Minimal example: write results for a single contrast
@@ -48,6 +49,7 @@ exampleTumourNormal \%>\%
   calculateDMRs(variable = "tumour", contrasts = "all") \%>\%
   annotateWindows(TxDb = "TxDb.Hsapiens.UCSC.hg38.knownGene", annoDb = "org.Hs.eg.db") \%>\%
   writeDMRsToExcel(path = file.path(tempdir(),"test.xlsx"))
+}
 }
 \seealso{
 \code{\link[=writeDMRsToBed]{writeDMRsToBed()}}


### PR DESCRIPTION
Fixes the TIMEOUT in R CMD check reported by the Bioconductor Single Package Builder.
See https://github.com/Bioconductor/Contributions/issues/4211#issuecomment-4373174046.

## Problem
R CMD check has a 15-minute hard limit. Examples collectively took >9 minutes
(makeQset: 94s, annotateWindows: 84s, plotGenomicFeatureDistribution: 74s,
plotGeneHeatmap: 144s elapsed, getDimRed: 28s, etc.), causing a TIMEOUT.

## Changes
- Wrapped all slow `@examples` (>5s) in `\donttest{}` across:
  `PCA.R`, `makeQset.R`, `qseaExtra.R`, `plotting.R`, `analyseDMRs.R`,
  `calculateEnrichment.R`
- Removed duplicate `@examples` block in `plotRegionsHeatmap`

## Not changed
`\dontrun{}` blocks in `qseaCNV.R`, `utilityFunctions.R`, `alterQset.R`,
`mixQsets.R`, `calculateEnrichment.R` were left as `\dontrun{}` — these
require BAM files or system resources that cannot run in any automated environment.

## Testing
`R CMD check --no-vignettes` completes with `checking examples ... OK` in ~4 minutes.
`devtools::run_examples()` passes with FAIL 0 | PASS 297.