### PR TITLE
chore(version): bump to 0.99.3.9000

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mesa
 Title: Methylation Enrichment Sequencing Analysis
-Version: 0.99.3
+Version: 0.99.3.9000
 Authors@R: c(
     person(given = "Simon",
            family = "Pearce",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# mesa 0.99.3.9000
+
+
 # mesa 0.99.3
 
 ## Documentation


### PR DESCRIPTION
Bumps the package version from `0.99.3` to `0.99.3.9000` to open the
development cycle.