### PR TITLE
chore(DESCRIPTION): bump version to 0.99.4.9000

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mesa
 Title: Methylation Enrichment Sequencing Analysis
-Version: 0.99.4
+Version: 0.99.4.9000
 Authors@R: c(
     person(given = "Simon",
            family = "Pearce",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # mesa 0.99.4.9000
 
+# mesa 0.99.4
+
 ## Testing
 - Guarded the slowest `testthat` blocks with `skip_long_checks()` to keep
   `R CMD check` within the Bioconductor 15-minute limit.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# mesa 0.99.4
+# mesa 0.99.4.9000
 
 ## Testing
 - Guarded the slowest `testthat` blocks with `skip_long_checks()` to keep


### PR DESCRIPTION
### Bump version to 0.99.4.9000

Adds the `.9000` development suffix to mark the repo as open for the next development cycle following the 0.99.4 release.

### Changes

- DESCRIPTION: Version: 0.99.4 → Version: 0.99.4.9000
- NEWS.md: Added new section → # mesa 0.99.4.9000