### PR TITLE
chore(version): bump to 0.99.5

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mesa
 Title: Methylation Enrichment Sequencing Analysis
-Version: 0.99.4.9000
+Version: 0.99.5
 Authors@R: c(
     person(given = "Simon",
            family = "Pearce",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# mesa 0.99.4.9000 
+# mesa 0.99.5
 
 ## Documentation
 - Replaced Unicode math symbols (`≥`, `≤`, `∈`) with ASCII equivalents (`>=`,


### PR DESCRIPTION
Bumps the package to the **0.99.5** release, mirroring #86.

- `DESCRIPTION`: `Version: 0.99.4.9000` → `0.99.5`
- `NEWS.md`: devel heading `# mesa 0.99.4.9000` → `# mesa 0.99.5`

_This PR was prepared by Claude (Claude Code)._