### PR TITLE
chore(DESCRIPTION): bump version to 0.99.5.9000

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mesa
 Title: Methylation Enrichment Sequencing Analysis
-Version: 0.99.5
+Version: 0.99.5.9000
 Authors@R: c(
     person(given = "Simon",
            family = "Pearce",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# mesa 0.99.5.9000
+
 # mesa 0.99.5
 
 ## Documentation


### PR DESCRIPTION
### Bump version to 0.99.5.9000

Adds the `.9000` development suffix to mark the repo as open for the next development cycle following the 0.99.5 release. Mirrors #87.

### Changes

- DESCRIPTION: `Version: 0.99.5` → `Version: 0.99.5.9000`
- NEWS.md: added new section → `# mesa 0.99.5.9000`

_This PR was prepared by Claude (Claude Code)._