### PR TITLE
fix(buildQset): replace defunct cigarWidthAlongReferenceSpace with cigarillo

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -74,7 +74,7 @@ Imports:
     BiocParallel,
     matrixStats,
     IRanges,
-    GenomicAlignments,
+    cigarillo,
     data.table,
     Rsamtools,
     tools,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # mesa 0.99.5.9000
 
+## Bug fixes
+- Replaced the defunct `GenomicAlignments::cigarWidthAlongReferenceSpace()` with
+  `cigarillo::cigar_extent_along_ref()`, fixing the vignette build on
+  Bioconductor devel (GenomicAlignments >= 1.49.1).
+
 # mesa 0.99.5
 
 ## Documentation

--- a/R/buildQset.R
+++ b/R/buildQset.R
@@ -318,7 +318,7 @@ getBamCoveragePairedAndUnpairedR1 <- function(fileName = NULL, BSgenome = NULL,
         dplyr::filter(
             # require good mapq and at least minReferenceLength ref span
             mapq >= minMapQual,
-            GenomicAlignments::cigarWidthAlongReferenceSpace(cigar) >=
+            cigarillo::cigar_extent_along_ref(cigar) >=
                 minReferenceLength
         )
 


### PR DESCRIPTION
### Problem

The Bioconductor submission build (r-universe biocstaging) fails while re-building the `generation.Rmd` vignette:

```
! cigarWidthAlongReferenceSpace() is defunct in GenomicAlignments >= 1.49.1 and
  replaced with the cigar_extent_along_ref() function from the new cigarillo package
```

`makeQset()` → `addBamCoveragePairedAndUnpaired()` calls `GenomicAlignments::cigarWidthAlongReferenceSpace()`, which is defunct on Bioconductor devel — the CIGAR helpers moved to the new `cigarillo` package.

### Fix

- `R/buildQset.R`: switch the R1 reference-length filter to `cigarillo::cigar_extent_along_ref()` (drop-in replacement).
- `DESCRIPTION`: add `cigarillo` to `Imports`; drop `GenomicAlignments` (confirmed to have no remaining use anywhere in the package, so it would otherwise be an unused import).
- `NEWS.md`: bug-fix entry under `# mesa 0.99.5.9000`.

_This PR was prepared by Claude (Claude Code)._