### PR TITLE
chore(version): bump to 0.99.6

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mesa
 Title: Methylation Enrichment Sequencing Analysis
-Version: 0.99.5.9000
+Version: 0.99.6
 Authors@R: c(
     person(given = "Simon",
            family = "Pearce",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# mesa 0.99.5.9000
+# mesa 0.99.6
 
 ## Bug fixes
 - Replaced the defunct `GenomicAlignments::cigarWidthAlongReferenceSpace()` with


### PR DESCRIPTION
Bumps the package to the **0.99.6** release, mirroring #94.

- `DESCRIPTION`: `Version: 0.99.5.9000` → `0.99.6`
- `NEWS.md`: devel heading `# mesa 0.99.5.9000` → `# mesa 0.99.6`

This release carries the cigarillo fix from #98, and the version bump re-triggers the Bioconductor biocstaging / single-package builder to re-review.

_This PR was prepared by Claude (Claude Code)._